### PR TITLE
#166267516]  add ads deletion endpoint

### DIFF
--- a/API/src/controllers/car.js
+++ b/API/src/controllers/car.js
@@ -84,3 +84,32 @@ exports.getOneAd =(req, res, next) =>{
            
   
 };
+exports.deleteAd= (req, res, next) => {
+  console.log(req.params)
+
+  const car= cars.find(car=> car.id === req.params.id )
+  console.log("then here second ")
+      if (!car) {
+        return res.status(401).json({
+          error: new Error('car not found !')
+        });
+      }
+      
+     
+      console.log("gotta delete ")
+
+      const index = cars.indexOf(car);
+      console.log(index)
+      console.log(cars[index])
+      cars.splice(index, 1);
+      console.log(req.body)
+
+  
+  console.log(cars[index])
+
+       return  res.status(200).json({
+          cars
+        });
+         
+
+};

--- a/API/src/db/automart.js
+++ b/API/src/db/automart.js
@@ -38,7 +38,31 @@
         "price" :"1215144",
         "created_on":"12/12/2018",
         "modified_on" :"112/12/2018"
-    }
+    },
+    {
+      "id" :"ffdfzfzef5f5zef5d5",
+      "owner" :"5545455dqsdq4ds",
+      "state":"new",
+      "status" :"available",
+      "body_type" :"truc",
+      "model" :"benz",
+      "manufacturer" :"mercedes",
+      "price" :"1215144",
+      "created_on":"12/12/2018",
+      "modified_on" :"112/12/2018"
+  },
+  {
+    "id" :"ffdfzfzef5f5zef54er",
+    "owner" :"5545455dqsdq4ds",
+    "state":"new",
+    "status" :"available",
+    "body_type" :"truc",
+    "model" :"benz",
+    "manufacturer" :"mercedes",
+    "price" :"1215144",
+    "created_on":"12/12/2018",
+    "modified_on" :"112/12/2018"
+}
        
     ];
   export  const  flags = [

--- a/API/src/routes/car.js
+++ b/API/src/routes/car.js
@@ -13,7 +13,7 @@ router.get('/', carCtrl.getAds );
 router.get('/:id', carCtrl.getOneAd );
 //router.put('/:id', auth, function(req, res){carCtrl.modifycar});
 router.delete('/:id',carCtrl.deleteAd);
-//router.patch('/:id/status', auth,function(req, res){ carCtrl.updateAdStatus});
+router.patch('/:id/status', carCtrl.updateAd);
 router.patch('/:id/price', carCtrl.updateAd);
 
 

--- a/API/src/routes/car.js
+++ b/API/src/routes/car.js
@@ -12,7 +12,7 @@ router.post('/', carCtrl.createAd );
 router.get('/', carCtrl.getAds );
 router.get('/:id', carCtrl.getOneAd );
 //router.put('/:id', auth, function(req, res){carCtrl.modifycar});
-//router.delete('/:id', auth,function(req, res){ carCtrl.deleteAd});
+router.delete('/:id',carCtrl.deleteAd);
 //router.patch('/:id/status', auth,function(req, res){ carCtrl.updateAdStatus});
 router.patch('/:id/price', carCtrl.updateAd);
 


### PR DESCRIPTION
#### What does this PR do?

- having delete ad endpoint work 

#### Description of Task to be completed?

- admin can delete any ads using this endpoint  /api/v1/car/`car id`

#### How should this be manually tested?

- after cloning this repo cd to API folder and type npm start in your terminal and 

- after you can test an API using postman by sending a DELETE request to   /api/v1/car/`car id`

#### What are the relevant pivotal tracker stories?

- #166267516

